### PR TITLE
Dynamic load balance

### DIFF
--- a/R/parameter_sweep.R
+++ b/R/parameter_sweep.R
@@ -17,7 +17,7 @@
 #' @export
 #' @importFrom dplyr group_by mutate ungroup sample_frac
 #' @importFrom tidyr nest unnest
-#' @importFrom furrr future_map
+#' @importFrom furrr future_map future_options
 #' @importFrom purrr safely
 #' @examples
 #'
@@ -103,7 +103,8 @@ parameter_sweep <- function(scenarios = NULL, samples = 1,
                precaution =.$precaution,
                self_report =.$self_report
       )[[1]],
-      .progress = show_progress
+      .progress = show_progress,
+      .options = furrr::future_options(scheduling = 20)
     )) %>%
     tidyr::unnest(cols = "data")
 


### PR DESCRIPTION
Assign jobs are they are completed rather than at initialization. Reduces run time by around 40% by optimizing core usage.